### PR TITLE
Enable multiline secrets view

### DIFF
--- a/KeyVaultExplorer/Views/Pages/PropertiesPage.axaml
+++ b/KeyVaultExplorer/Views/Pages/PropertiesPage.axaml
@@ -140,46 +140,53 @@
                             BorderThickness="1"
                             CornerRadius="4"
                             IsVisible="{Binding IsSecret}">
-                            <ScrollViewer VerticalScrollBarVisibility="Visible">
-                                <Border>
-                                    <StackPanel VerticalAlignment="Stretch">
-                                    <Grid ColumnDefinitions="*,Auto" RowDefinitions="*"  VerticalAlignment="Stretch">
-                                        <TextBlock
-                                            Grid.Column="0"
-                                            HorizontalAlignment="Left"
-                                            VerticalAlignment="Bottom"
-                                            IsVisible="{Binding !#ShowToggleButton.IsChecked}"
-                                            Text="{Binding SecretHidden}"
-                                            />
-                                        <SelectableTextBlock
-                                            Grid.Column="0"
-                                            HorizontalAlignment="Left"
-                                            VerticalAlignment="Center"
-                                            xml:space="preserve"
-                                            IsVisible="{Binding #ShowToggleButton.IsChecked}"
-                                            Text="{Binding SecretPlainText}" />
-                                        <ToggleButton
-                                            Name="ShowToggleButton"
-                                            Grid.Column="1"
-                                            Height="30"
-                                            HorizontalAlignment="Right"
-                                            VerticalAlignment="Top"
-                                            Command="{Binding ShouldShowValueCommand}"
-                                            CommandParameter="{Binding ShowValue}"
-                                            Content="&#xE7B3;"
-                                            CornerRadius="4"
-                                            FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                            FontSize="20"
-                                            IsChecked="{Binding ShowValue}"
-                                            RenderOptions.TextRenderingMode="Antialias"
-                                            Theme="{StaticResource TransparentToggleButton}"
-                                            ToolTip.Tip="Show/Hide"
-                                            ToolTip.VerticalOffset="10"
-                                            ZIndex="1" />
-                                    </Grid>
-                                </StackPanel>
+                            <Grid ColumnDefinitions="*,Auto" RowDefinitions="*" VerticalAlignment="Stretch">
+                                <Border
+                                    MaxHeight="200"
+                                    Grid.Column="0"
+                                    IsVisible="True"
+                                    Padding="0"
+                                    BorderThickness="1" 
+                                    CornerRadius="4">
+                                    <ScrollViewer
+                                        VerticalScrollBarVisibility="Visible">
+                                        <StackPanel
+                                            VerticalAlignment="Top">
+                                            <TextBlock
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Center"
+                                                IsVisible="{Binding !#ShowToggleButton.IsChecked}"
+                                                Text="{Binding SecretHidden}" />
+                                            <TextBlock
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Top"
+                                                TextWrapping="Wrap"
+                                                IsVisible="{Binding #ShowToggleButton.IsChecked}"
+                                                Text="{Binding SecretPlainText}" />
+                                        </StackPanel>
+
+                                    </ScrollViewer>
                                 </Border>
-                            </ScrollViewer>
+
+                                <ToggleButton
+                                    Name="ShowToggleButton"
+                                    Grid.Column="1"
+                                    Height="30"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Top"
+                                    Command="{Binding ShouldShowValueCommand}"
+                                    CommandParameter="{Binding ShowValue}"
+                                    Content="&#xE7B3;"
+                                    CornerRadius="4"
+                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                    FontSize="20"
+                                    IsChecked="{Binding ShowValue}"
+                                    RenderOptions.TextRenderingMode="Antialias"
+                                    Theme="{StaticResource TransparentToggleButton}"
+                                    ToolTip.Tip="Show/Hide"
+                                    ToolTip.VerticalOffset="10"
+                                    ZIndex="1" />
+                            </Grid>
                         </Border>
 
                         <!--<Button

--- a/KeyVaultExplorer/Views/Pages/PropertiesPage.axaml
+++ b/KeyVaultExplorer/Views/Pages/PropertiesPage.axaml
@@ -132,49 +132,54 @@
                     Margin="8,0,8,0"
                     HorizontalAlignment="Stretch"
                     DockPanel.Dock="Top">
-                    <Grid ColumnDefinitions="*,Auto" RowDefinitions="*,*,*">
+                    <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,*,*">
                         <Border
-                            Height="35"
                             Padding="8"
                             Background="{DynamicResource LayerFillColorDefaultBrush}"
                             BorderBrush="{StaticResource ControlElevationBorderBrush}"
                             BorderThickness="1"
                             CornerRadius="4"
                             IsVisible="{Binding IsSecret}">
-                            <Grid ColumnDefinitions="*,Auto" RowDefinitions="*">
-
-                                <TextBlock
-                                    Grid.Column="0"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Bottom"
-                                    IsVisible="{Binding !#ShowToggleButton.IsChecked}"
-                                    Text="{Binding SecretHidden}" />
-                                <SelectableTextBlock
-                                    Grid.Column="0"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center"
-                                    xml:space="preserve"
-                                    IsVisible="{Binding #ShowToggleButton.IsChecked}"
-                                    Text="{Binding SecretPlainText}" />
-                                <ToggleButton
-                                    Name="ShowToggleButton"
-                                    Grid.Column="1"
-                                    Height="30"
-                                    HorizontalAlignment="Right"
-                                    VerticalAlignment="Center"
-                                    Command="{Binding ShouldShowValueCommand}"
-                                    CommandParameter="{Binding ShowValue}"
-                                    Content="&#xE7B3;"
-                                    CornerRadius="4"
-                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                    FontSize="20"
-                                    IsChecked="{Binding ShowValue}"
-                                    RenderOptions.TextRenderingMode="Antialias"
-                                    Theme="{StaticResource TransparentToggleButton}"
-                                    ToolTip.Tip="Show/Hide"
-                                    ToolTip.VerticalOffset="10"
-                                    ZIndex="1" />
-                            </Grid>
+                            <ScrollViewer VerticalScrollBarVisibility="Visible">
+                                <Border>
+                                    <StackPanel VerticalAlignment="Stretch">
+                                    <Grid ColumnDefinitions="*,Auto" RowDefinitions="*"  VerticalAlignment="Stretch">
+                                        <TextBlock
+                                            Grid.Column="0"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Bottom"
+                                            IsVisible="{Binding !#ShowToggleButton.IsChecked}"
+                                            Text="{Binding SecretHidden}"
+                                            />
+                                        <SelectableTextBlock
+                                            Grid.Column="0"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            xml:space="preserve"
+                                            IsVisible="{Binding #ShowToggleButton.IsChecked}"
+                                            Text="{Binding SecretPlainText}" />
+                                        <ToggleButton
+                                            Name="ShowToggleButton"
+                                            Grid.Column="1"
+                                            Height="30"
+                                            HorizontalAlignment="Right"
+                                            VerticalAlignment="Top"
+                                            Command="{Binding ShouldShowValueCommand}"
+                                            CommandParameter="{Binding ShowValue}"
+                                            Content="&#xE7B3;"
+                                            CornerRadius="4"
+                                            FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                            FontSize="20"
+                                            IsChecked="{Binding ShowValue}"
+                                            RenderOptions.TextRenderingMode="Antialias"
+                                            Theme="{StaticResource TransparentToggleButton}"
+                                            ToolTip.Tip="Show/Hide"
+                                            ToolTip.VerticalOffset="10"
+                                            ZIndex="1" />
+                                    </Grid>
+                                </StackPanel>
+                                </Border>
+                            </ScrollViewer>
                         </Border>
 
                         <!--<Button


### PR DESCRIPTION
Viewing an existing secret with a multiline value shows now all lines of the value 